### PR TITLE
Change Java9 List.of() to Arrays.asList()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+.idea
+
+target

--- a/src/main/java/ScorchServer/ServerShell/ServerShell.java
+++ b/src/main/java/ScorchServer/ServerShell/ServerShell.java
@@ -12,7 +12,7 @@ import ScorchServer.ScorchServer;
 import ScorchServer.ServerShell.commands.*;
 
 public class ServerShell implements Runnable {
-    public final List<shellCommand> commands = List.of(
+    public final List<shellCommand> commands = Arrays.asList(
             new addkg(),
             new boot(),
             new desync(),

--- a/src/main/java/scorch/items/Item.java
+++ b/src/main/java/scorch/items/Item.java
@@ -23,7 +23,7 @@ public abstract class Item {
     };
 
     static java.util.List<Item> generateItems() {
-        return java.util.List.of(
+        return Arrays.asList(
                 new Shield(),
                 new MediumShield(),
                 new HeavyShield(),

--- a/src/main/java/scorch/weapons/Weapon.java
+++ b/src/main/java/scorch/weapons/Weapon.java
@@ -10,6 +10,7 @@ package scorch.weapons;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.function.Supplier;
 
@@ -35,7 +36,7 @@ public abstract class Weapon extends Item {
     };
 
     static java.util.List<Weapon> generateWeapons() {
-        return java.util.List.of(
+        return Arrays.asList(
                 new Missile(),
                 new BabyNuke(),
                 new Nuke(),


### PR DESCRIPTION
List.of() is a Java9 construct.  Java 8 should use Arrays.asList() instead.

Also adds a .gitignore for IntelliJ and other Java build outputs.